### PR TITLE
fix: throw exception on form submit error

### DIFF
--- a/Classes/Service/HubSpotService.php
+++ b/Classes/Service/HubSpotService.php
@@ -56,6 +56,8 @@ class HubSpotService
 			],
 		];
 
+        $response = null;
+
 		try {
 			$response = $this->hubspotApi->apiRequest($requestOptions);
 		} catch (\GuzzleHttp\Exception\ClientException $e) {

--- a/Classes/Service/HubSpotService.php
+++ b/Classes/Service/HubSpotService.php
@@ -56,15 +56,7 @@ class HubSpotService
 			],
 		];
 
-        $response = null;
-
-		try {
-			$response = $this->hubspotApi->apiRequest($requestOptions);
-		} catch (\GuzzleHttp\Exception\ClientException $e) {
-            $this->logger->error('Error during form submit to HubSpot: '. $e->getMessage());
-		}
-
-		return $response;
+        return $this->hubspotApi->apiRequest($requestOptions);
 	}
 
 }


### PR DESCRIPTION
During `submitForm` a default value for `$response` is set. In case of `catch` during `try` the default value will be returned instead of an exception thrown, because of an unknown variable.