### PR TITLE
fix: throw exception on form submit error

### DIFF
--- a/Classes/Service/HubSpotService.php
+++ b/Classes/Service/HubSpotService.php
@@ -56,6 +56,8 @@ class HubSpotService
 			],
 		];
 
+        $response = null;
+
 		try {
 			$response = $this->hubspotApi->apiRequest($requestOptions);
 		} catch (\GuzzleHttp\Exception\ClientException $e) {

--- a/Classes/Service/HubSpotService.php
+++ b/Classes/Service/HubSpotService.php
@@ -56,15 +56,7 @@ class HubSpotService
 			],
 		];
 
-        $response = null;
-
-		try {
-			$response = $this->hubspotApi->apiRequest($requestOptions);
-		} catch (\GuzzleHttp\Exception\ClientException $e) {
-            $this->logger->error('Error during form submit to HubSpot: '. $e->getMessage());
-		}
-
-		return $response;
+        return $this->hubspotApi->apiRequest($requestOptions);
 	}
 
 }

--- a/Classes/Service/HubSpotService.php
+++ b/Classes/Service/HubSpotService.php
@@ -4,6 +4,7 @@ namespace FormatD\HubSpot\Service;
 
 use HubSpot\Discovery\Discovery;
 use Neos\Flow\Annotations as Flow;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -41,9 +42,9 @@ class HubSpotService
 	 * @param array $formFields
 	 * @param array $context
 	 * @param array $legalConsentOptions
-	 * @return \Psr\Http\Message\ResponseInterface
+	 * @return ResponseInterface
 	 */
-	public function submitForm(string $formGuid, array $formFields, array $context, array $legalConsentOptions): \Psr\Http\Message\ResponseInterface {
+	public function submitForm(string $formGuid, array $formFields, array $context, array $legalConsentOptions): ResponseInterface {
 
 		$requestOptions = [
 			'method' => 'POST',

--- a/Classes/Service/HubSpotService.php
+++ b/Classes/Service/HubSpotService.php
@@ -5,7 +5,6 @@ namespace FormatD\HubSpot\Service;
 use HubSpot\Discovery\Discovery;
 use Neos\Flow\Annotations as Flow;
 use Psr\Http\Message\ResponseInterface;
-use Psr\Log\LoggerInterface;
 
 /**
  * @Flow\Scope("singleton")
@@ -23,12 +22,6 @@ class HubSpotService
 	 * @var Discovery
 	 */
 	protected Discovery $hubspotApi;
-
-    /**
-     * @Flow\Inject
-     * @var LoggerInterface
-     */
-    protected $logger;
 
 	/**
 	 * @return void


### PR DESCRIPTION
During `submitForm` an exception is thrown when an error occurs during HubSpot API request. Error will not be logged anymore.